### PR TITLE
領域制限の機能を追加

### DIFF
--- a/Prototype/hozumi/calculation.py
+++ b/Prototype/hozumi/calculation.py
@@ -53,18 +53,18 @@ def calculate_score(xy_vectors_1: np.ndarray, xy_vectors_2: np.ndarray, label: n
     not_detect_score: np.ndarray = not_detect_label * score_perfect * calc_penalty(label)
     sum_penalty_score: float = not_detect_score.sum()
     #print(not_detect_score)
-    print(sum_penalty_score)
+    #print(sum_penalty_score)
     #完全一致の場合のスコアを算出
     score_whole = np.sum(score_perfect * label)
     #未検出のベクトルにペナルティを入れる場合は下を使う
     #score_whole = np.sum(score_perfect)
     # print(f"label:{label}")
     # print(f"score_perfect：{score_perfect}")
-    print(f"分子：{sum_points}")
+    #print(f"分子：{sum_points}")
     
     # ペナルティを加算
     score_whole += calc_penalty(label)
-    print(f"分母：{score_whole}")
+    #print(f"分母：{score_whole}")
 
     return sum_points / score_whole
 
@@ -84,7 +84,7 @@ def calculate_cos(xy_vectors_1: np.ndarray, xy_vectors_2: np.ndarray) -> np.ndar
 
 def calc_penalty(label: np.ndarray) -> float:
     not_detect_sum: int = np.sum(label == 0)
-    print(f"not：{not_detect_sum}")
+    #print(f"not：{not_detect_sum}")
     # シグモイド関数を利用してみる
     #penalty: float = sigmoid(not_detect_sum)
 

--- a/Prototype/hozumi/functions.py
+++ b/Prototype/hozumi/functions.py
@@ -1,7 +1,7 @@
 import cv2
 from typing import Tuple, List
 import numpy as np
-from settings import SCALE_UP
+from settings import SCALE_UP, X_LIMIT_START, Y_LIMIT_START
 
 
 def get_draw_info(pt1: np.ndarray, pt2: np.ndarray) -> List[Tuple[int, int]]:
@@ -14,10 +14,10 @@ def get_draw_info(pt1: np.ndarray, pt2: np.ndarray) -> List[Tuple[int, int]]:
     Returns:
         List[Tuple[int, int]]: それぞれのxy座標をタプルでまとめたリスト
     """    
-    pt1_x = int(pt1[0] * SCALE_UP)
-    pt1_y = int(pt1[1] * SCALE_UP)
-    pt2_x = int(pt2[0] * SCALE_UP)
-    pt2_y = int(pt2[1] * SCALE_UP)
+    pt1_x = int(pt1[0] * SCALE_UP + X_LIMIT_START)
+    pt1_y = int(pt1[1] * SCALE_UP + Y_LIMIT_START)
+    pt2_x = int(pt2[0] * SCALE_UP + X_LIMIT_START)
+    pt2_y = int(pt2[1] * SCALE_UP + Y_LIMIT_START)
     
     return [(pt1_x, pt1_y), (pt2_x, pt2_y)]
 

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -5,7 +5,7 @@ import openpifpaf
 from PIL import Image
 from typing import List, Tuple
 from functions import draw_line, create_connected, calculate_cos, created_three_connected
-from settings import SCALE_UP, TIMER
+from settings import SCALE_UP, TIMER, X_LIMIT_START, Y_LIMIT_START, X_LIMIT_END, Y_LIMIT_END
 from calculation import compare_pose
 from vector_functions import correct_vectors
 
@@ -60,7 +60,7 @@ while capture.isOpened():
     frame：RGBの値を持っている3次元の配列データ ex) サイズ (480, 640, 3) 高さ、幅、色チャネル
     """
     # タイマーの計測開始
-    # TIMER.start()
+    TIMER.start()
 
     read_video: Tuple[bool, np.ndarray] = capture.read()
     success, frame = read_video
@@ -69,9 +69,10 @@ while capture.isOpened():
     if not success :
         print( "frame is None" )
         break
-    
-    
-    resize_frame: np.ndarray = cv2.resize(frame, dsize=None, fx=(1.0 / SCALE_UP), fy=(1.0 / SCALE_UP))
+    # img[top : bottom, left : right]
+    #limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
+    limit_frame = frame
+    resize_frame: np.ndarray = cv2.resize(limit_frame, dsize=None, fx=(1.0 / SCALE_UP), fy=(1.0 / SCALE_UP))
 
     predictions, gt_anns, meta = predictor.numpy_image(resize_frame)
     """
@@ -90,19 +91,20 @@ while capture.isOpened():
 
     if len(people_vectors) >= 1:
         similarity = compare_pose(people_vectors[0], people_vectors[0]) * 100
-        print(f"類似度：{similarity}")
-        print("---------------------------")
+        # print(f"類似度：{similarity}")
+        # print("---------------------------")
 
     height = frame.shape[0]
     width = frame.shape[1]
+    #annotated_image = cv2.rectangle(annotated_image, (X_LIMIT_START, Y_LIMIT_START), (X_LIMIT_END, Y_LIMIT_END), (0,255,0), thickness=2)
     annotated_image = cv2.flip(annotated_image, 1)
     bigger_frame = cv2.resize(annotated_image, (int(width) * 2, int(height) * 2))
     cv2.imshow('Camera 1',bigger_frame)
     #cv2.moveWindow("Camera 1", 200,40)
     calc(predictions, 0)
 
-    # TIMER.end()
-    # TIMER.calc_speed()
+    TIMER.end()
+    TIMER.calc_speed()
 
     # ESCキーを押すと終了
     if cv2.waitKey(100) == 0x1b:

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -70,8 +70,8 @@ while capture.isOpened():
         print( "frame is None" )
         break
     # img[top : bottom, left : right]
-    #limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
-    limit_frame = frame
+    limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
+    #limit_frame = frame
     resize_frame: np.ndarray = cv2.resize(limit_frame, dsize=None, fx=(1.0 / SCALE_UP), fy=(1.0 / SCALE_UP))
 
     predictions, gt_anns, meta = predictor.numpy_image(resize_frame)
@@ -96,7 +96,7 @@ while capture.isOpened():
 
     height = frame.shape[0]
     width = frame.shape[1]
-    #annotated_image = cv2.rectangle(annotated_image, (X_LIMIT_START, Y_LIMIT_START), (X_LIMIT_END, Y_LIMIT_END), (0,255,0), thickness=2)
+    annotated_image = cv2.rectangle(annotated_image, (X_LIMIT_START, Y_LIMIT_START), (X_LIMIT_END, Y_LIMIT_END), (0,255,0), thickness=2)
     annotated_image = cv2.flip(annotated_image, 1)
     bigger_frame = cv2.resize(annotated_image, (int(width) * 2, int(height) * 2))
     cv2.imshow('Camera 1',bigger_frame)

--- a/Prototype/hozumi/settings.py
+++ b/Prototype/hozumi/settings.py
@@ -3,6 +3,10 @@ import numpy as np
 
 SCALE_UP = 3.5
 TIMER = Timer()
+X_LIMIT_START = 170
+Y_LIMIT_START = 100
+X_LIMIT_END = 480
+Y_LIMIT_END = 480
 
 weight = np.ones(13)
 


### PR DESCRIPTION
- 関節点抽出をするエリアを制限する機能を追加しました
- 参考までにタイマーで1フレームあたりの処理時間をテストした結果を
    - 【エリア制限あり】0.05500531196594238
    -  【制限なし】0.10400056838989258

- 領域制限はsetting.pyに追加した変数から調整できます