### PR TITLE
並行処理のロジックを大幅に変更

### DIFF
--- a/Prototype/hozumi/SynchronizeProcess.py
+++ b/Prototype/hozumi/SynchronizeProcess.py
@@ -1,0 +1,21 @@
+from multiprocessing import Value, Lock
+
+class SharedRunning:
+    def __init__(self):
+        self._value = Value('i', True)
+        self._lock = Lock()
+        self._obj = Value('i', False)
+
+    @property
+    def value(self):
+        return self._value.value
+
+    @value.setter
+    def value(self, new_value):
+        self._value.value = new_value
+
+    def get_obj(self):
+        return self._value
+
+    def get_lock(self):
+        return self._lock

--- a/Prototype/hozumi/functions.py
+++ b/Prototype/hozumi/functions.py
@@ -120,3 +120,33 @@ def calculate_cos(pt1: np.ndarray, pt2: np.ndarray, pt3: np.ndarray) -> float:
     degree: float = np.rad2deg(rad)
     return degree
 
+def draw_landmarks(image: np.ndarray, landmarks: List) -> np.ndarray:
+
+    annotated_image = image.copy()
+    # ランドマークとして検出されている点を囲む矩形を描画する
+    # body_rectangle: List[float] = landmarks[0].json_data()["bbox"]
+    # base_x, base_y, width, height = body_rectangle
+
+    # x1 = int(base_x)
+    # y1 = int(base_y - 10)
+    # x2 = int(base_x+width)
+    # y2 = int(base_x+height)
+    # # 解像度1/4にしたので、4倍して位置を調整
+    # cv2.rectangle(annotated_image, (x1*SCALE,y1*SCALE), (x2*SCALE, y2*SCALE), (255, 255, 255))
+
+    connected_keypoints = create_connected(landmarks, index=0)
+    for (pt1, pt2) in connected_keypoints:
+        if((0 in pt1) or (0 in pt2)): continue # 座標をうまく取得できなかったとき
+        annotated_image = draw_line(annotated_image, pt1, pt2)
+    
+    return annotated_image
+
+def calc(landmarks: np.ndarray, index: int):
+    connected: List[Tuple[np.ndarray, np.ndarray, np.ndarray]] = created_three_connected(landmarks, index)
+    index = 0
+    for (pt1, pt2, pt3) in connected:
+        if((0 in pt1) or (0 in pt2) or (0 in pt3)): continue
+        # print("index: ", end="")
+        # print(index)
+        # index += 1
+        # print(calculate_cos(pt1, pt2, pt3))

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -20,12 +20,12 @@ if __name__ == '__main__':
         # キューからフレームを取得
         frame = queue.get()
         cv2.imshow('frame', frame)
-        if cv2.waitKey(1) & 0xFF == 27:  # ESCキーが押されたら
+        if cv2.waitKeyEx(1) & 0xFF == 27:  # ESCキーが押されたら
             running.value = False
 
         if countdown_process is None:
             # カウントダウンプロセスが動作していない場合
-            if cv2.waitKey(1) == 13:  # Enterキーが押されたら
+            if cv2.waitKeyEx(1) == 13:  # Enterキーが押されたら
                 # カウントダウンプロセスの作成
                 countdown_process = mp.Process(target=countdown, args=(queue, running))
                 countdown_process.start()

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -1,125 +1,31 @@
-import cv2
-import numpy as np
-import openpifpaf
-from typing import List, Tuple
-from functions import draw_line, create_connected, calculate_cos, created_three_connected
-from settings import SCALE_UP, TIMER, X_LIMIT_START, Y_LIMIT_START, X_LIMIT_END, Y_LIMIT_END, COUNT_X, COUNT_Y
-from calculation import compare_pose
-from vector_functions import correct_vectors
-import threading
+import multiprocessing as mp
+from multiprocessing import Queue;
 import time
-from queue import Queue
+import cv2
+from multi_process import countdown, capture_frames
 
-predictor = openpifpaf.Predictor(checkpoint = "shufflenetv2k16")
+if __name__ == '__main__':
+     # キューの作成
+    queue: Queue = Queue(maxsize=10)
+    running = mp.Value('i', True)
 
-def draw_landmarks(image: np.ndarray, landmarks: List) -> np.ndarray:
+    # ビデオキャプチャプロセスの作成
+    video_process = mp.Process(target=capture_frames, args=(queue, running))
+    video_process.start()
 
-    annotated_image = image.copy()
-    # ランドマークとして検出されている点を囲む矩形を描画する
-    # body_rectangle: List[float] = landmarks[0].json_data()["bbox"]
-    # base_x, base_y, width, height = body_rectangle
-
-    # x1 = int(base_x)
-    # y1 = int(base_y - 10)
-    # x2 = int(base_x+width)
-    # y2 = int(base_x+height)
-    # # 解像度1/4にしたので、4倍して位置を調整
-    # cv2.rectangle(annotated_image, (x1*SCALE,y1*SCALE), (x2*SCALE, y2*SCALE), (255, 255, 255))
-
-    connected_keypoints = create_connected(landmarks, index=0)
-    for (pt1, pt2) in connected_keypoints:
-        if((0 in pt1) or (0 in pt2)): continue # 座標をうまく取得できなかったとき
-        annotated_image = draw_line(annotated_image, pt1, pt2)
-    
-    return annotated_image
-
-def calc(landmarks: np.ndarray, index: int):
-    connected: List[Tuple[np.ndarray, np.ndarray, np.ndarray]] = created_three_connected(landmarks, index)
-    index = 0
-    for (pt1, pt2, pt3) in connected:
-        if((0 in pt1) or (0 in pt2) or (0 in pt3)): continue
-        # print("index: ", end="")
-        # print(index)
-        # index += 1
-        # print(calculate_cos(pt1, pt2, pt3))
-
-# PCに繋がっているUSBカメラから撮る場合はこれ
-capture = cv2.VideoCapture(0)
-
-if not capture.isOpened(): # 正常に動画読み込めなかったとき
-    print( "Error opening capture device")
-    capture.release() # カメラデバイス閉じる
-    cv2.destroyAllWindows() # 開いているすべてのウィンドウ閉じる
-    exit()
-
-if capture.isOpened(): # 正常に読みこめたとき
-    print( "Device captured correctly",capture)
+    # カウントダウンプロセスの作成
+    countdown_process = mp.Process(target=countdown, args=(queue, running))
+    countdown_process.start()
 
 
+    while running.value:
+        # キューからフレームを取得
+        frame = queue.get()
+        cv2.imshow('frame', frame)
+        if cv2.waitKey(1) & 0xFF == 27:  # ESCキーが押されたら
 
-while capture.isOpened():
-    """
-    success：画像の取得が成功したか
-    frame：RGBの値を持っている3次元の配列データ ex) サイズ (480, 640, 3) 高さ、幅、色チャネル
-    """
+            running.value = False
 
-    read_video: Tuple[bool, np.ndarray] = capture.read()
-    success, frame = read_video
-
-    if not success :
-        print( "frame is None" )
-        break
-    # img[top : bottom, left : right]
-    limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
-    #limit_frame = frame
-    resize_frame: np.ndarray = cv2.resize(limit_frame, dsize=None, fx=(1.0 / SCALE_UP), fy=(1.0 / SCALE_UP))
-
-    predictions, gt_anns, meta = predictor.numpy_image(resize_frame)
-    """
-    predictions：関節座標
-    インデックス：関節座標点
-    """
-    if len(predictions) == 0: continue
-    annotated_image: np.ndarray = draw_landmarks(frame, predictions)
-    #predictions[0].data[0] : (x,y,c)
-
-    people_vectors: np.ndarray = np.zeros((len(predictions), 13, 2, 3))
-
-    for person_id in range(len(predictions)):
-        vectors = correct_vectors(predictions, person_id)
-        people_vectors[person_id] = np.asarray(vectors)
-
-    if len(people_vectors) >= 1:
-        similarity = compare_pose(people_vectors[0], people_vectors[0]) * 100
-        # print(f"類似度：{similarity}")
-        # print("---------------------------")
-
-    height = frame.shape[0]
-    width = frame.shape[1]
-    annotated_image = cv2.rectangle(annotated_image, (X_LIMIT_START, Y_LIMIT_START), (X_LIMIT_END, Y_LIMIT_END), (0,255,0), thickness=2)
-    annotated_image = cv2.flip(annotated_image, 1)
-
-    # print("frame1 =",frame)
-
-    bigger_frame = cv2.resize(annotated_image, (int(width) * 2, int(height) * 2))
-    cv2.imshow('Camera 1',bigger_frame)
-    #cv2.moveWindow("Camera 1", 200,40)
-    calc(predictions, 0)
-
-    # TIMER.end()
-    # TIMER.calc_speed()
-
-    # ESCキーを押すと終了
-    
-    # 数値100で0.1s秒キー入力待つ
-    # ※ここがボトルネックの一因になってた可能性あり※
-    # 100->1でめっちゃぬるぬる動くように、、、
-    if cv2.waitKey(1) == 0x1b:
-        print('ESC pressed. Exiting ...')
-        break
-
-    # タイマーの計測開始
-    # TIMER.start()
-capture.release()
-cv2.destroyAllWindows()
-
+    video_process.terminate()
+    countdown_process.terminate()
+    cv2.destroyAllWindows()

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -3,29 +3,38 @@ from multiprocessing import Queue;
 import time
 import cv2
 from multi_process import countdown, capture_frames
+from SynchronizeProcess import SharedRunning
 
 if __name__ == '__main__':
      # キューの作成
     queue: Queue = Queue(maxsize=10)
-    running = mp.Value('i', True)
+    running = SharedRunning()
 
     # ビデオキャプチャプロセスの作成
     video_process = mp.Process(target=capture_frames, args=(queue, running))
     video_process.start()
-
-    # カウントダウンプロセスの作成
-    countdown_process = mp.Process(target=countdown, args=(queue, running))
-    countdown_process.start()
-
+    # カウントダウンプロセスの初期化
+    countdown_process = None
 
     while running.value:
         # キューからフレームを取得
         frame = queue.get()
         cv2.imshow('frame', frame)
         if cv2.waitKey(1) & 0xFF == 27:  # ESCキーが押されたら
-
             running.value = False
 
+        if countdown_process is None:
+            # カウントダウンプロセスが動作していない場合
+            if cv2.waitKey(1) == 13:  # Enterキーが押されたら
+                # カウントダウンプロセスの作成
+                countdown_process = mp.Process(target=countdown, args=(queue, running))
+                countdown_process.start()
+        elif not countdown_process.is_alive():
+            # カウントダウンプロセスが停止している場合
+            countdown_process = None
+
+
     video_process.terminate()
-    countdown_process.terminate()
+    if countdown_process is not None:
+        countdown_process.terminate()
     cv2.destroyAllWindows()

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -2,16 +2,17 @@ import multiprocessing as mp
 from multiprocessing import Queue;
 import time
 import cv2
-from multi_process import countdown, capture_frames
+from multi_process import countdown, capture_frames, take_screenshot
 from SynchronizeProcess import SharedRunning
 
 if __name__ == '__main__':
      # キューの作成
     queue: Queue = Queue(maxsize=10)
+    queue2: Queue = Queue(maxsize=10)
     running = SharedRunning()
 
     # ビデオキャプチャプロセスの作成
-    video_process = mp.Process(target=capture_frames, args=(queue, running))
+    video_process = mp.Process(target=capture_frames, args=(queue, running, queue2))
     video_process.start()
     # カウントダウンプロセスの初期化
     countdown_process = None
@@ -19,6 +20,7 @@ if __name__ == '__main__':
     while running.value:
         # キューからフレームを取得
         frame = queue.get()
+        normal_frame = queue2.get()
         cv2.imshow('frame', frame)
         if cv2.waitKey(1) & 0xFF == 27:  # ESCキーが押されたら
             running.value = False
@@ -32,7 +34,8 @@ if __name__ == '__main__':
         elif not countdown_process.is_alive():
             # カウントダウンプロセスが停止している場合
             countdown_process = None
-
+            screenshot_process = mp.Process(target=take_screenshot, args=(queue2, ))
+            screenshot_process.start()
 
     video_process.terminate()
     if countdown_process is not None:

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -20,14 +20,14 @@ if __name__ == '__main__':
         # キューからフレームを取得
         frame = queue.get()
         cv2.imshow('frame', frame)
-        if cv2.waitKeyEx(1) & 0xFF == 27:  # ESCキーが押されたら
+        if cv2.waitKey(1) & 0xFF == 27:  # ESCキーが押されたら
             running.value = False
 
         if countdown_process is None:
             # カウントダウンプロセスが動作していない場合
-            if cv2.waitKeyEx(1) == 13:  # Enterキーが押されたら
+            if cv2.waitKey(1) & 0xFF == 13:  # Enterキーが押されたら
                 # カウントダウンプロセスの作成
-                countdown_process = mp.Process(target=countdown, args=(queue, running))
+                countdown_process = mp.Process(target=countdown, args=(queue, running, 5))
                 countdown_process.start()
         elif not countdown_process.is_alive():
             # カウントダウンプロセスが停止している場合

--- a/Prototype/hozumi/hozumi_main.py
+++ b/Prototype/hozumi/hozumi_main.py
@@ -11,24 +11,6 @@ import time
 from queue import Queue
 
 predictor = openpifpaf.Predictor(checkpoint = "shufflenetv2k16")
-q: Queue = Queue()
-frame_q: Queue = Queue()
-temp = None
-isPlayerTurn: bool = False # 真似する人のターンだったらTrueに
-
-
-def screenshot(frame: np.ndarray):
-    """画面のスクショを疑似的に撮るための関数
-       ここから画像送ったりしましょう
-
-    Args:
-        frame (np.ndarray): 任意のタイミングのスクショ
-    """
-    global isPlayerTurn
-
-    isPlayerTurn = not isPlayerTurn
-    #cv2.imwrite(filename="test.png", img=frame)
-    return frame
 
 def draw_landmarks(image: np.ndarray, landmarks: List) -> np.ndarray:
 
@@ -60,15 +42,6 @@ def calc(landmarks: np.ndarray, index: int):
         # print(index)
         # index += 1
         # print(calculate_cos(pt1, pt2, pt3))
-
-def countDown(counts: int):
-    global temp
-    for i in range(counts+1): 
-        time.sleep(1)
-        print(i)
-        q.put(counts-i)
-    time.sleep(1)
-    temp = None
 
 # PCに繋がっているUSBカメラから撮る場合はこれ
 capture = cv2.VideoCapture(0)
@@ -128,18 +101,6 @@ while capture.isOpened():
 
     # print("frame1 =",frame)
 
-    if not q.empty():
-        temp = q.get()
-        if temp == 0:
-            pic_thread = threading.Thread(target=screenshot, args=(frame, ))
-            pic_thread.start()
-            pic_thread.join()
-        print(f"time: {temp}")
-
-    if temp != None:
-        cv2.putText(annotated_image, text=f"count: {temp}", org=(COUNT_X, COUNT_Y), fontFace=cv2.FONT_HERSHEY_TRIPLEX,
-                fontScale=2.0, color=(0,255,0), thickness=2,lineType=cv2.LINE_4)
-
     bigger_frame = cv2.resize(annotated_image, (int(width) * 2, int(height) * 2))
     cv2.imshow('Camera 1',bigger_frame)
     #cv2.moveWindow("Camera 1", 200,40)
@@ -159,16 +120,6 @@ while capture.isOpened():
 
     # タイマーの計測開始
     # TIMER.start()
-    if cv2.waitKey(1) == ord('c'):
-        if threading.active_count() <= 1:
-            thread = threading.Thread(target=countDown, args=(5,))
-            thread.setDaemon(True)
-            thread.start()
-
-    if isPlayerTurn and threading.active_count() <= 1:
-        playerThread = threading.Thread(target=countDown, args=(5, ))
-        playerThread.setDaemon(True)
-        playerThread.start()
 capture.release()
 cv2.destroyAllWindows()
 

--- a/Prototype/hozumi/multi_process.py
+++ b/Prototype/hozumi/multi_process.py
@@ -1,0 +1,104 @@
+import cv2
+import numpy as np
+import openpifpaf
+from typing import List, Tuple
+from functions import draw_landmarks
+from settings import SCALE_UP, TIMER, X_LIMIT_START, Y_LIMIT_START, X_LIMIT_END, Y_LIMIT_END, COUNT_X, COUNT_Y
+from calculation import compare_pose
+from vector_functions import correct_vectors
+import time
+
+def add_countdown(frame, count):
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    if count >= 0:
+        cv2.putText(frame, str(count), (300, 300), font, 7, (0, 255, 255), 10, cv2.LINE_AA)
+    else:
+        cv2.putText(frame, '', (300, 300), font, 7, (0, 255, 255), 10, cv2.LINE_AA)
+    return frame
+
+def countdown(queue, running):
+    # 5秒カウントダウン
+    for i in range(3, -1, -1):
+        print(i)
+        for j in range(30):
+            if not running.value:
+                return         
+            frame = queue.get()
+            frame = add_countdown(frame, i)
+            queue.put(frame)
+
+            
+    while running.value:
+        frame = queue.get()
+        frame = add_countdown(frame, -1)
+        queue.put(frame)
+
+
+def capture_frames(queue, running):
+
+    predictor = openpifpaf.Predictor(checkpoint = "shufflenetv2k16")
+
+    # PCに繋がっているUSBカメラから撮る場合はこれ
+    capture = cv2.VideoCapture(0)
+
+    if not capture.isOpened(): # 正常に動画読み込めなかったとき
+        print( "Error opening capture device")
+        capture.release() # カメラデバイス閉じる
+        cv2.destroyAllWindows() # 開いているすべてのウィンドウ閉じる
+        exit()
+
+    if capture.isOpened(): # 正常に読みこめたとき
+        print( "Device captured correctly",capture)
+
+
+    while capture.isOpened():
+        """
+        success：画像の取得が成功したか
+        frame：RGBの値を持っている3次元の配列データ ex) サイズ (480, 640, 3) 高さ、幅、色チャネル
+        """
+        if not running.value: return
+        read_video: Tuple[bool, np.ndarray] = capture.read()
+        success, frame = read_video
+        if not success :
+            print( "frame is None" )
+            break
+        # img[top : bottom, left : right]
+        limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
+        #limit_frame = frame
+        resize_frame: np.ndarray = cv2.resize(limit_frame, dsize=None, fx=(1.0 / SCALE_UP), fy=(1.0 / SCALE_UP))
+
+        predictions, gt_anns, meta = predictor.numpy_image(resize_frame)
+        """
+        predictions：関節座標
+        インデックス：関節座標点
+        """
+        if len(predictions) == 0: continue
+        annotated_image: np.ndarray = draw_landmarks(frame, predictions)
+        #predictions[0].data[0] : (x,y,c)
+
+        people_vectors: np.ndarray = np.zeros((len(predictions), 13, 2, 3))
+
+        for person_id in range(len(predictions)):
+            vectors = correct_vectors(predictions, person_id)
+            people_vectors[person_id] = np.asarray(vectors)
+
+        if len(people_vectors) >= 1:
+            similarity = compare_pose(people_vectors[0], people_vectors[0]) * 100
+            # print(f"類似度：{similarity}")
+            # print("---------------------------")
+
+        height = frame.shape[0]
+        width = frame.shape[1]
+        annotated_image = cv2.rectangle(annotated_image, (X_LIMIT_START, Y_LIMIT_START), (X_LIMIT_END, Y_LIMIT_END), (0,255,0), thickness=2)
+        annotated_image = cv2.flip(annotated_image, 1)
+
+        # print("frame1 =",frame)
+
+        bigger_frame = cv2.resize(annotated_image, (int(width) * 2, int(height) * 2))
+        queue.put(bigger_frame)
+
+
+    # タイマーの計測開始
+    # TIMER.start()
+    capture.release()
+

--- a/Prototype/hozumi/multi_process.py
+++ b/Prototype/hozumi/multi_process.py
@@ -26,12 +26,7 @@ def countdown(queue, running):
             frame = queue.get()
             frame = add_countdown(frame, i)
             queue.put(frame)
-
-            
-    while running.value:
-        frame = queue.get()
-        frame = add_countdown(frame, -1)
-        queue.put(frame)
+    return 
 
 
 def capture_frames(queue, running):

--- a/Prototype/hozumi/multi_process.py
+++ b/Prototype/hozumi/multi_process.py
@@ -28,8 +28,16 @@ def countdown(queue: mp.Queue, running, count: int):
             queue.put(frame)
     return 
 
+def take_screenshot(q2: mp.Queue) -> None:
+    frames = []
+    while not q2.empty():
+        frame = q2.get()
+        frames.append(frame)
+    if frames:
+        #cv2.imwrite(filename="screenshot.png", img=frames[-1])
+        pass
 
-def capture_frames(queue, running):
+def capture_frames(queue: mp.Queue, running, q2: mp.Queue):
 
     predictor = openpifpaf.Predictor(checkpoint = "shufflenetv2k16")
 
@@ -57,6 +65,7 @@ def capture_frames(queue, running):
         if not success :
             print( "frame is None" )
             break
+        q2.put(frame)
         # img[top : bottom, left : right]
         limit_frame = frame[Y_LIMIT_START:Y_LIMIT_END, X_LIMIT_START:X_LIMIT_END]
         #limit_frame = frame

--- a/Prototype/hozumi/multi_process.py
+++ b/Prototype/hozumi/multi_process.py
@@ -6,9 +6,9 @@ from functions import draw_landmarks
 from settings import SCALE_UP, TIMER, X_LIMIT_START, Y_LIMIT_START, X_LIMIT_END, Y_LIMIT_END, COUNT_X, COUNT_Y
 from calculation import compare_pose
 from vector_functions import correct_vectors
-import time
+import multiprocessing as mp
 
-def add_countdown(frame, count):
+def add_countdown(frame: np.ndarray, count: int):
     font = cv2.FONT_HERSHEY_SIMPLEX
     if count >= 0:
         cv2.putText(frame, str(count), (300, 300), font, 7, (0, 255, 255), 10, cv2.LINE_AA)
@@ -16,9 +16,9 @@ def add_countdown(frame, count):
         cv2.putText(frame, '', (300, 300), font, 7, (0, 255, 255), 10, cv2.LINE_AA)
     return frame
 
-def countdown(queue, running):
+def countdown(queue: mp.Queue, running, count: int):
     # 5秒カウントダウン
-    for i in range(3, -1, -1):
+    for i in range(count, -1, -1):
         print(i)
         for j in range(30):
             if not running.value:


### PR DESCRIPTION
- threadingモジュールからmultiprocessingモジュールに変更
- hozumi_main.pyに記載するコードを必要最小限に
- 並行処理に関する関数をmulti_process.pyに分離して、汎用化
    - 多分、だいぶ再利用しやすくはなったはず

【想定動作】
- Enter押下　→　5秒カウント　→　スクショ